### PR TITLE
Fix date to not start from 1970 in Scala Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "perfolation",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
     )
   )
 
@@ -55,7 +55,7 @@ lazy val unit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "perfolation-unit",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
     )
   )
 

--- a/core/native/src/main/scala/perfolation/Platform.scala
+++ b/core/native/src/main/scala/perfolation/Platform.scala
@@ -1,12 +1,12 @@
 package perfolation
 
-import scala.scalanative.unsafe.stackalloc
+import scala.scalanative.unsafe._
 import scala.scalanative.posix.time.time_t
 
 object Platform {
   def createDate(l: Long): CrossDate = {
     val bmsptr = stackalloc[time_t]()
-    bmsptr(l / 1000L)
+    !bmsptr = (l / 1000L).toCSSize
 
     new NativeCrossDate(l, bmsptr)
   }


### PR DESCRIPTION
Fix scalatest dependency to be cross platform.
Tests were not running on Scala Native and Scala.js